### PR TITLE
Added Monad instantiation for Mem

### DIFF
--- a/src/Ch15Ex-Monoid.hs
+++ b/src/Ch15Ex-Monoid.hs
@@ -239,16 +239,31 @@ instance (Monoid a, Semigroup a) => Monoid (Comp a) where
   mempty = Comp mempty
   mappend = (<>)
 
--- 9. Mem
+-- 9. Mem Copy and run in new file
+--import Data.Monoid 
+--newtype Mem s a = 
+--     Mem {
+--        runMem :: s -> (a,s)
+--   }
 
-newtype Mem s a =
-  Mem {
-    runMem :: s -> (a, s)
-    }
+-- instance Monoid a => Monoid (Mem s a) where
+--      mempty = Mem $ (\s -> (mempty,s)) 
+--      mappend (Mem {runMem = f}) (Mem {runMem = g}) = 
+--         Mem $ (\x -> let 
+--                     (u,q) = f x
+--                     (v,w) = g q
+--                     in
+--                     (u <> v,w))
+                           
 
-instance Monoid a => Monoid (Mem s a) where
-  mempty = undefined
-  mappend = undefined
+-- f' = Mem $ (\s -> ("hi",s+1))
+
+-- testMem = do 
+--     print $ runMem (f' <> mempty) 0
+--     print $ runMem (mempty <> f') 0
+--     print $ (runMem mempty 0 :: (String,Int))
+--     print $ runMem (f' <> mempty) 0 == runMem f' 0
+--     print $ runMem (mempty <> f') 0 == runMem f' 0
 
 -- main
 


### PR DESCRIPTION
To run code, uncomment block, and comment out import statement for semigroup due to conflicting definitions of '<>'. Better to copy to new file (lines 242 - 266)